### PR TITLE
Refactored the Auth plug 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ after_success:
 env:
   global:
   - MIX_ENV=test
-  - SECRET_KEY_BASE=2PzB7PPnpuLsbWmWtXpGyI+kfSQSQ1zUW2Atz/+8PdZuSEJzHgzGnJWV35nTKRwx
+  - AUTH_API_KEY=2PzB7PPnpuLsbWmWtXpGyI+kfSQSQ1zUW2Atz/+8PdZuSEJzHgzGnJWV35nTKRwx

--- a/README.md
+++ b/README.md
@@ -272,31 +272,6 @@ please
 we are here to help!
 
 
-
-
-
-<br />
-
-
-### (_Optional+Recommended_) Update `endpoint.ex`
-
-Open your `endpoint.ex` file and update the line that reads:
-
-```elixir
-plug Plug.Session, @session_options
-```
-
-To:
-```elixir
-plug Plug.Session, AuthPlug.session_options
-```
-
-This will avoid noise in your server logs
-from the default Phoenix Session config,
-which **`auth_plug`** overrides to use JWTs.
-
-[`/lib/app_web/endpoint.ex#L45`](https://github.com/dwyl/auth_plug_example/blob/4730e3079d2cff375385cdc3b8f73e252f41883f/lib/app_web/endpoint.ex#L45)
-
 <br />
 
 ## Documentation

--- a/lib/auth_plug.ex
+++ b/lib/auth_plug.ex
@@ -26,66 +26,54 @@ defmodule AuthPlug do
   else redirect to the `auth_url` with the referer set as the continuation URL.
   """
   def call(conn, options) do
-    # Setup Plug.Session
-    conn = setup_session(conn)
 
-    # Locate JWT so we can attempt to verify it:
-    jwt =
-      cond do
-        # First Check for JWT in URL Query String.
-        # We want a *new* session to supercede any expired session,
-        #  so the check for JWT *before* anything else.
-        conn.query_string =~ "jwt" ->
-          query = URI.decode_query(conn.query_string)
-          Map.get(query, "jwt")
+    jwt = get_jwt(conn)
 
-        # Check for JWT in Headers:
-        Enum.count(get_req_header(conn, "authorization")) > 0 ->
-          conn.req_headers
-          |> List.keyfind("authorization", 0)
-          |> get_token_from_header()
+    case AuthPlug.Token.verify_jwt(jwt) do
+      {:ok, values} ->
+        put_current_token(conn, jwt, values)
 
-        #  Check for Person in Plug.Conn.assigns
-        Map.has_key?(conn.assigns, :jwt) && not is_nil(conn.assigns.jwt) ->
-          conn.assigns.jwt
-
-        # Check for Session in Plug.Session:
-        not is_nil(get_session(conn, :jwt)) ->
-          get_session(conn, :jwt)
-
-        # By default return nil so auth check fails
-        true ->
-          nil
-      end
-
-    validate_token(conn, jwt, options)
+      # log the JWT verify error then redirect:
+      {:error, reason} ->
+        Logger.error(Kernel.inspect(reason))
+        redirect_to_auth(conn, options)
+    end
   end
 
-  @doc """
-  `session_options/0` returns the list of Phoenix/Plug Session options.
-  This is useful if you need to check them or use them somewhere else.
-  """
-  def session_options() do
-    [
-      store: :cookie,
-      key: "_auth_key",
-      secret_key_base: System.get_env("SECRET_KEY_BASE"),
-      signing_salt: AuthPlug.Token.client_secret
-    ]
+  defp get_jwt(conn) do
+    cond do
+      # First Check for JWT in URL Query String.
+      # We want a *new* session to supercede any expired session,
+      #  so the check for JWT *before* anything else.
+      conn.query_string =~ "jwt" ->
+        query = URI.decode_query(conn.query_string)
+        Map.get(query, "jwt")
+
+      # Check for JWT in Headers:
+      Enum.count(get_req_header(conn, "authorization")) > 0 ->
+        conn.req_headers
+        |> List.keyfind("authorization", 0)
+        |> get_token_from_header()
+
+      #  Check for Person in Plug.Conn.assigns
+      Map.has_key?(conn.assigns, :jwt) && not is_nil(conn.assigns.jwt) ->
+        conn.assigns.jwt
+
+      # Check for Session in Plug.Session:
+      not is_nil(get_session(conn, :jwt)) ->
+        get_session(conn, :jwt)
+
+      # By default return nil so auth check fails
+      true ->
+        nil
+    end
   end
 
-  @doc """
-  `setup_session/1` configures the Phoenix/Plug Session.
-  """
-  def setup_session(conn) do
-    conn = put_in(conn.secret_key_base, System.get_env("SECRET_KEY_BASE"))
-
-    opts = session_options() |> Plug.Session.init()
-
-    conn
-    |> Plug.Session.call(opts)
-    |> fetch_session()
-    |> configure_session(renew: true)
+  def put_current_token(conn, jwt, values) do
+    # convert map of string to atom: stackoverflow.com/questions/31990134
+    claims = for {k, v} <- values, into: %{}, do: {String.to_atom(k), v}
+    # return the conn with the session
+    create_session(conn, claims, jwt)
   end
 
   @doc """
@@ -94,7 +82,7 @@ defmodule AuthPlug do
   and the JWT as the value so that it can be checked
   on each future request.
   Makes the decoded JWT available in conn.assigns
-  which means it can be used in templates. 
+  which means it can be used in templates.
   """
   def create_session(conn, claims, jwt) do
     claims = AuthPlug.Helpers.strip_struct_metadata(claims)
@@ -102,6 +90,7 @@ defmodule AuthPlug do
     |> assign(:person, claims)
     |> assign(:jwt, jwt)
     |> put_session(:jwt, jwt)
+    |> configure_session(renew: true)
   end
 
   @doc """
@@ -117,9 +106,8 @@ defmodule AuthPlug do
     jwt = claims # delete %Auth.Person github.com/dwyl/auth_plug/issues/16
       |> AuthPlug.Helpers.strip_struct_metadata()
       |> AuthPlug.Token.generate_jwt!()
-    conn
-      |> setup_session()
-      |> create_session(claims, jwt)
+
+    create_session(conn, claims, jwt)
   end
 
   #  fail fast if no JWT in auth header:
@@ -128,7 +116,7 @@ defmodule AuthPlug do
   defp get_token_from_header({"authorization", value}) do
     value = String.replace(value, "Bearer", "") |> String.trim()
     # fast check for JWT format validity before slower verify:
-    if is_nil(value) do
+    if is_nil(value) do # Does this ever eval to true?
       nil
     else
       case Enum.count(String.split(value, ".")) == 3 do
@@ -139,25 +127,6 @@ defmodule AuthPlug do
         true ->
           value
       end
-    end
-  end
-
-  # if jwt is nil fail fast
-  defp validate_token(conn, nil, opts), do: redirect_to_auth(conn, opts)
-
-  # attempt to validate a valid-looking JWT:
-  defp validate_token(conn, jwt, opts) do
-    case AuthPlug.Token.verify_jwt(jwt) do
-      {:ok, values} ->
-        # convert map of string to atom: stackoverflow.com/questions/31990134
-        claims = for {k, v} <- values, into: %{}, do: {String.to_atom(k), v}
-        # return the conn with the session
-        create_session(conn, claims, jwt)
-
-      # log the JWT verify error then redirect:
-      {:error, reason} ->
-        Logger.error(Kernel.inspect(reason))
-        redirect_to_auth(conn, opts)
     end
   end
 

--- a/lib/demo/application.ex
+++ b/lib/demo/application.ex
@@ -4,15 +4,16 @@ defmodule AuthPlug.Application do
   use Application
   require Logger
   @data %{email: "alexa@gmail.com", name: "Alexa"}
-  @jwt AuthPlug.Token.generate_jwt!(@data)
 
   def start(_type, _args) do
     children = [
       {Plug.Cowboy, scheme: :http, plug: AuthPlug.Router, options: [port: 4000]}
     ]
 
+    jwt = AuthPlug.Token.generate_jwt!(@data)
+
     Logger.info("First visit: http://localhost:4000/admin")
-    Logger.info("Then visit: http://localhost:4000/admin?jwt=" <> @jwt)
+    Logger.info("Then visit: http://localhost:4000/admin?jwt=" <> jwt)
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: App.Supervisor]

--- a/lib/token.ex
+++ b/lib/token.ex
@@ -76,6 +76,11 @@ defmodule AuthPlug.Token do
   `verify_jwt/1` verifies the given JWT and returns {:ok, claims}
   where the claims are the original data that were signed.
   """
+  def verify_jwt(nil) do
+    # Fail fast on a nil token
+    {:error, "No jwt provided"}
+  end
+
   def verify_jwt(token) do
     verify_jwt(token, client_secret())
   end

--- a/test/auth_plug_test.exs
+++ b/test/auth_plug_test.exs
@@ -1,5 +1,5 @@
 defmodule AuthPlugTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   use Plug.Test
   alias AuthPlug.Token
   @opts AuthPlug.init(%{auth_url: "https://dwylauth.herokuapp.com"})
@@ -8,73 +8,100 @@ defmodule AuthPlugTest do
     assert AuthPlug.init(%{}) == %{}
   end
 
-  test "Plug return 401 wiht not Authorization Header" do
-    conn = AuthPlug.call(conn(:get, "/admin"), @opts)
+  describe "test admin endpoint" do
+    setup %{endpoint: endpoint} do
+      test_conn =
+        conn(:get, "endpoint")
+        |> init_test_session(%{})
 
-    # redirect when auth fails
-    assert conn.status == 302
-  end
+      {:ok, conn: test_conn}
+    end
 
-  test "Plug return 401 wiht incorrect jwt header" do
-    conn =
-      conn(:get, "/admin")
-      |> put_req_header("authorization", "Bearer incorrect.jwt")
-      |> AuthPlug.call(@opts)
+    @tag endpoint: "/admin"
+    test "Plug return 401 wiht not Authorization Header", %{conn: conn} do
+      # conn = AuthPlug.call(conn(:get, "/admin"), @opts)
+      # fetch_session(conn)
+      # redirect when auth fails
+      conn = AuthPlug.call(conn, @opts)
+      assert conn.status == 302
+    end
 
-    # redirect when auth fails
-    assert conn.status == 302
-  end
+    @tag endpoint: "/admin"
+    test "Plug return 401 wiht incorrect jwt header", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer incorrect.jwt")
+        |> AuthPlug.call(@opts)
 
-  test "Fail when authorization header token is invalid" do
-    conn =
-      conn(:get, "/admin")
-      |> put_req_header("authorization", "Bearer this.will.fail")
-      |> AuthPlug.call(@opts)
+      # redirect when auth fails
+      assert conn.status == 302
+    end
 
-    # redirect when auth fails
-    assert conn.status == 302
-  end
+    @tag endpoint: "/admin"
+    test "Fail when authorization header token is invalid", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer this.will.fail")
+        |> AuthPlug.call(@opts)
 
-  test "Conn.assign decoded (the verified JWT)" do
-    data = %{email: "alex@dwyl.com", name: "Alex"}
-    jwt = Token.generate_jwt!(data)
+      # redirect when auth fails
+      assert conn.status == 302
+    end
 
-    conn =
-      conn(:get, "/admin")
-      |> assign(:jwt, jwt)
-      |> AuthPlug.call(%{})
+    @tag endpoint: "/admin"
+    test "Conn.assign decoded (the verified JWT)", %{conn: conn} do
+      data = %{email: "alex@dwyl.com", name: "Alex"}
+      jwt = Token.generate_jwt!(data)
 
-    assert conn.assigns.person.email == "alex@dwyl.com"
-  end
+      conn =
+        conn
+        |> assign(:jwt, jwt)
+        |> AuthPlug.call(%{})
 
-  test "get_session(conn, :jwt)" do
-    data = %{email: "alice@dwyl.com", name: "Alice"}
-    jwt = Token.generate_jwt!(data)
+      assert conn.assigns.person.email == "alex@dwyl.com"
+    end
 
-    conn =
-      conn(:get, "/admin")
-      |> AuthPlug.setup_session()
-      |> put_session(:jwt, jwt)
-      |> AuthPlug.call(@opts)
+    @tag endpoint: "/admin"
+    test "get_session(conn, :jwt)", %{conn: conn} do
+      data = %{email: "alice@dwyl.com", name: "Alice"}
+      jwt = Token.generate_jwt!(data)
 
-    token = get_session(conn, :jwt)
-    {:ok, decoded} = AuthPlug.Token.verify_jwt(token)
-    assert Map.get(decoded, "email") == "alice@dwyl.com"
-  end
+      conn =
+        conn
+        |> put_session(:jwt, jwt)
+        |> AuthPlug.call(@opts)
 
-  test "Plug assigns person=jwt to conn with valid jwt" do
-    data = %{email: "person@dwyl.com", session: 1}
-    jwt = Token.generate_jwt!(data)
+      token = get_session(conn, :jwt)
+      {:ok, decoded} = AuthPlug.Token.verify_jwt(token)
+      assert Map.get(decoded, "email") == "alice@dwyl.com"
+    end
 
-    conn =
-      conn(:get, "/admin")
-      |> put_req_header("authorization", "Bearer #{jwt}")
-      |> AuthPlug.call(%{})
+    @tag endpoint: "/admin"
+    test "Plug assigns person=jwt to conn with valid jwt", %{conn: conn} do
+      data = %{email: "person@dwyl.com", session: 1}
+      jwt = Token.generate_jwt!(data)
 
-    token = conn.assigns.jwt
-    person = AuthPlug.Token.verify_jwt!(token)
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{jwt}")
+        |> AuthPlug.call(%{})
 
-    assert person["email"] == "person@dwyl.com"
+      token = conn.assigns.jwt
+      person = AuthPlug.Token.verify_jwt!(token)
+
+      assert person["email"] == "person@dwyl.com"
+    end
+
+    @tag endpoint: "/"
+    test "create_session_mock/2", %{conn: conn} do
+      claims = %{email: "person@dwyl.com", id: 1}
+
+      conn =
+        conn
+        |> AuthPlug.create_jwt_session(claims)
+
+      assert conn.assigns.person == claims
+    end
   end
 
   test "Extract JWT from URL" do
@@ -83,20 +110,10 @@ defmodule AuthPlugTest do
 
     conn =
       conn(:get, "/admin?jwt=" <> jwt)
-      |> AuthPlug.setup_session()
+      |> init_test_session(%{})
       |> put_session(:jwt, nil)
       |> AuthPlug.call(%{})
 
     assert conn.assigns.person.email == "person@dwyl.com"
   end
-
-  test "create_session_mock/2" do
-    claims = %{email: "person@dwyl.com", id: 1}
-    conn =
-      conn(:get, "/")
-      |> AuthPlug.create_jwt_session(claims)
-
-    assert conn.assigns.person == claims
-  end
-
 end


### PR DESCRIPTION
I have refactored the main Auth plug so it stops tampering with the session and is not a bit easier to follow (I hope).

The main changes are:
* `call` is now much shorter and it is clearer to see what happens to the `conn`
* Finding the jwt has been moved out of call and into a separate function
* `setup_session` has been removed, I don't *think* it was needed as it was never called outside of the plug and phoenix already sets up the session as part of the `browser` pipeline. This also makes it easier to add api authorisation in future which isn't dependent on session.
* Tests have been refactored to setup a test `conn` and removed references to the removed `setup_session`

TODO
- [x] Update documentation
- [ ] Add an error when correct environment variables aren't set *(? possibly - this should probably be in another PR)