### PR TITLE
Add a human readable error message when API key is not set

### DIFF
--- a/lib/auth_plug.ex
+++ b/lib/auth_plug.ex
@@ -16,6 +16,7 @@ defmodule AuthPlug do
   """
   def init(options) do
     # return options unmodified
+    AuthPlug.Helpers.check_environment_vars()
     options
   end
 

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -26,4 +26,11 @@ defmodule AuthPlug.Helpers do
     |> Map.delete(:login_logs) # association
     |> Map.delete(:email_hash) # binary
   end
+
+  def check_environment_vars do
+    key = AuthPlug.Token.api_key()
+    if is_nil(key) do
+      raise "No AUTH_API_KEY set, find out how at https://github.com/dwyl/auth_plug#2-get-your-auth_api_key-"
+    end
+  end
 end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -30,7 +30,7 @@ defmodule AuthPlug.Helpers do
   def check_environment_vars do
     key = AuthPlug.Token.api_key()
     if is_nil(key) do
-      raise "No AUTH_API_KEY set, find out how at https://github.com/dwyl/auth_plug#2-get-your-auth_api_key-"
+      raise "No AUTH_API_KEY set, find out how at: https://git.io/JJ6sS"
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AuthPlug.MixProject do
   def project do
     [
       app: :auth_plug,
-      version: "1.1.1",
+      version: "1.2.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AuthPlug.MixProject do
   def project do
     [
       app: :auth_plug,
-      version: "1.2.0",
+      version: "1.2.1",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/auth_plug_test.exs
+++ b/test/auth_plug_test.exs
@@ -11,7 +11,7 @@ defmodule AuthPlugTest do
   describe "test admin endpoint" do
     setup %{endpoint: endpoint} do
       test_conn =
-        conn(:get, "endpoint")
+        conn(:get, endpoint)
         |> init_test_session(%{})
 
       {:ok, conn: test_conn}

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -19,4 +19,21 @@ defmodule AuthPlugHelpersTest do
 
     assert get_baseurl_from_conn(conn) == "https://dwyl.com"
   end
+
+  test "check_environment_vars raises error if AUTH_API_KEY is not set" do
+    key = System.get_env("AUTH_API_KEY")
+    # delete the environment variable:
+    System.delete_env("AUTH_API_KEY")
+
+    # confirm that the correct error is raised:
+    assert_raise RuntimeError,
+    "No AUTH_API_KEY set, find out how at: https://git.io/JJ6sS",
+    fn ->
+      check_environment_vars()
+    end
+    # see: til.hashrocket.com/posts/0b1f205523-assert-an-exception-is-raised
+
+    # restore the environment variable:
+    System.put_env("AUTH_API_KEY", key)
+  end
 end


### PR DESCRIPTION
This helps to fix #19 

The demo app breaks during compilation without an API key, otherwise this error will appear on a human readable error page in Phoenix.

In compilation the error gets shown like this:
```
== Compilation error in file lib/demo/router.ex ==
** (RuntimeError) No AUTH_API_KEY set, find out how at https://github.com/dwyl/auth_plug#2-get-your-auth_api_key-
    lib/helpers.ex:33: AuthPlug.Helpers.check_environment_vars/0
    lib/auth_plug.ex:19: AuthPlug.init/1
    lib/plug/builder.ex:304: Plug.Builder.init_module_plug/4
    lib/plug/builder.ex:288: anonymous fn/5 in Plug.Builder.compile/3
    (elixir 1.10.3) lib/enum.ex:2111: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/plug/builder.ex:286: Plug.Builder.compile/3
    expanding macro: Plug.Builder.__before_compile__/1
    lib/demo/router.ex:1: AuthPlug.Router (module)
```

Which I still think is a big improvement over obscure pattern matching errors