### PR TITLE
Document the values in `conn.assigns`

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,10 +290,10 @@ By default using the dwylauth.herokuapp.com authentication service,
 ```
 jwt :: string()
 person :: %{
+  id :: integer() # This stays unique across providers
   auth_provider :: string()
   email :: string()
-  givenName :: string()
-  id :: integer()
+  givenName :: string() 
   picture :: string()
   
   # Also includes standard jwt metadata you may find useful:

--- a/README.md
+++ b/README.md
@@ -283,6 +283,23 @@ but if _anything_ is unclear,
 please open an issue:
 https://github.com/dwyl/auth_plug/issues
 
+### Availiable infomation
+By default using the dwylauth.herokuapp.com authentication service,
+`auth_plug` makes the following infomation availiable in `conn.assigns`:
+
+```
+jwt :: string()
+person :: %{
+  auth_provider :: string()
+  email :: string()
+  givenName :: string()
+  id :: integer()
+  picture :: string()
+  
+  # Also includes standard jwt metadata you may find useful:
+  aud, exp, iat, iss
+}
+```
 
 
 ## Recommended / Relevant Reading


### PR DESCRIPTION
Couldn't find these values documented anywhere, so I've added them to the `Documentation` part of the readme. 

Let me know if there's somewhere more suited for this documentation.

I've presumed the assigns set stay constant - e.g. is `id` the same across sessions/identity providers? 